### PR TITLE
GetTx method in Entity interface

### DIFF
--- a/action.go
+++ b/action.go
@@ -21,7 +21,7 @@ type Availabler interface {
 	IsAvailable(ctx context.Context) bool
 }
 
-type ActionDoFunc func(ctx context.Context, id interface{}, opts ...interface{}) error
+type ActionDoFunc func(ctx context.Context, entity Entity, opts ...interface{}) error
 
 type Entity interface {
 	StartAction(ctx context.Context) (context.Context, error)
@@ -29,4 +29,5 @@ type Entity interface {
 	SetState(ctx context.Context, newState uint64, params ...interface{}) error
 	EndAction(ctx context.Context, err error) error
 	GetId() interface{}
+	GetTx() interface{}
 }

--- a/example_fromstruct_test.go
+++ b/example_fromstruct_test.go
@@ -37,7 +37,7 @@ func (i *ExampleImpl) ActionTest() multistate.Action {
 		From:    Any(),
 		Set:     multistate.States{i.St2},
 		Reset:   nil,
-		OnDo: func(ctx context.Context, id interface{}, opts ...interface{}) error {
+		OnDo: func(ctx context.Context, entity multistate.Entity, opts ...interface{}) error {
 			return nil
 		},
 	}
@@ -53,6 +53,7 @@ func (*ExampleEntity) GetState(context.Context) (uint64, error)                 
 func (*ExampleEntity) SetState(context.Context, uint64, ...interface{}) error   { return nil }
 func (*ExampleEntity) EndAction(context.Context, error) error                   { return nil }
 func (e *ExampleEntity) GetId() interface{}                                     { return e.Id }
+func (*ExampleEntity) GetTx() interface{}                                       { return nil }
 
 func ExampleNewFromStruct() {
 	mst := multistate.NewFromStruct(&ExampleImpl{})

--- a/multistate_test.go
+++ b/multistate_test.go
@@ -35,6 +35,10 @@ func (testEntity) GetId() interface{} {
 	return 1
 }
 
+func (testEntity) GetTx() interface{} {
+	return nil
+}
+
 func TestMultistate_DoAction(t *testing.T) {
 	mst := multistate.New("New")
 
@@ -48,7 +52,7 @@ func TestMultistate_DoAction(t *testing.T) {
 	mst.MustAddAction(
 		"sign_a", "Sign A", Empty(),
 		multistate.States{signedA}, nil,
-		func(_ context.Context, _ interface{}, _ ...interface{}) error {
+		func(_ context.Context, _ multistate.Entity, _ ...interface{}) error {
 			return nil
 		},
 		nil,
@@ -57,7 +61,7 @@ func TestMultistate_DoAction(t *testing.T) {
 	mst.MustAddAction(
 		"sign_b", "Sign B", Empty(),
 		multistate.States{signedB}, nil,
-		func(_ context.Context, _ interface{}, _ ...interface{}) error {
+		func(_ context.Context, _ multistate.Entity, _ ...interface{}) error {
 			return nil
 		},
 		nil,
@@ -66,7 +70,7 @@ func TestMultistate_DoAction(t *testing.T) {
 	mst.MustAddAction(
 		"sign_c", "Sign C", And(Or(signedA, signedB), Not(signedC)),
 		multistate.States{signedC}, nil,
-		func(_ context.Context, _ interface{}, _ ...interface{}) error {
+		func(_ context.Context, _ multistate.Entity, _ ...interface{}) error {
 			return nil
 		},
 		nil,
@@ -75,7 +79,7 @@ func TestMultistate_DoAction(t *testing.T) {
 	mst.MustAddAction(
 		"sign_d", "Sign D", And(Or(signedC, signedE), Not(signedD)),
 		multistate.States{signedD}, nil,
-		func(_ context.Context, _ interface{}, _ ...interface{}) error {
+		func(_ context.Context, _ multistate.Entity, _ ...interface{}) error {
 			return nil
 		},
 		nil,
@@ -84,7 +88,7 @@ func TestMultistate_DoAction(t *testing.T) {
 	mst.MustAddAction(
 		"sign_e", "Sign E", And(Or(signedC, signedD), Not(signedE)),
 		multistate.States{signedE}, nil,
-		func(_ context.Context, _ interface{}, _ ...interface{}) error {
+		func(_ context.Context, _ multistate.Entity, _ ...interface{}) error {
 			return nil
 		},
 		nil,
@@ -93,7 +97,7 @@ func TestMultistate_DoAction(t *testing.T) {
 	mst.MustAddAction(
 		"sign_f", "Sign F", And(signedD, signedE, Not(signedF)),
 		multistate.States{signedF}, nil,
-		func(_ context.Context, _ interface{}, _ ...interface{}) error {
+		func(_ context.Context, _ multistate.Entity, _ ...interface{}) error {
 			return nil
 		},
 		nil,
@@ -139,7 +143,7 @@ func TestMultistate_DoAction2(t *testing.T) {
 	mst.MustAddAction(
 		"sign_a", "Sign A", Empty(),
 		multistate.States{signedA}, nil,
-		func(_ context.Context, _ interface{}, _ ...interface{}) error {
+		func(_ context.Context, _ multistate.Entity, _ ...interface{}) error {
 			return nil
 		},
 		nil,
@@ -148,7 +152,7 @@ func TestMultistate_DoAction2(t *testing.T) {
 	mst.MustAddAction(
 		"sign_b", "Sign B", Empty(),
 		multistate.States{signedB}, nil,
-		func(_ context.Context, _ interface{}, _ ...interface{}) error {
+		func(_ context.Context, _ multistate.Entity, _ ...interface{}) error {
 			return nil
 		},
 		nil,
@@ -157,7 +161,7 @@ func TestMultistate_DoAction2(t *testing.T) {
 	mst.MustAddAction(
 		"sign_c", "Sign C", And(Or(signedA, signedB), Not(signedC)),
 		multistate.States{signedC}, multistate.States{signedA, signedB},
-		func(_ context.Context, _ interface{}, _ ...interface{}) error {
+		func(_ context.Context, _ multistate.Entity, _ ...interface{}) error {
 			return nil
 		},
 		nil,
@@ -166,7 +170,7 @@ func TestMultistate_DoAction2(t *testing.T) {
 	mst.MustAddAction(
 		"sign_d", "Sign D", And(Or(signedC, signedE), Not(signedD)),
 		multistate.States{signedD}, multistate.States{signedC},
-		func(_ context.Context, _ interface{}, _ ...interface{}) error {
+		func(_ context.Context, _ multistate.Entity, _ ...interface{}) error {
 			return nil
 		},
 		nil,
@@ -175,7 +179,7 @@ func TestMultistate_DoAction2(t *testing.T) {
 	mst.MustAddAction(
 		"sign_e", "Sign E", And(Or(signedC, signedD), Not(signedE)),
 		multistate.States{signedE}, multistate.States{signedC},
-		func(_ context.Context, _ interface{}, _ ...interface{}) error {
+		func(_ context.Context, _ multistate.Entity, _ ...interface{}) error {
 			return nil
 		},
 		nil,
@@ -184,7 +188,7 @@ func TestMultistate_DoAction2(t *testing.T) {
 	mst.MustAddAction(
 		"sign_f", "Sign F", And(signedD, signedE, Not(signedF)),
 		multistate.States{signedF}, multistate.States{signedD, signedE},
-		func(_ context.Context, _ interface{}, _ ...interface{}) error {
+		func(_ context.Context, _ multistate.Entity, _ ...interface{}) error {
 			return nil
 		},
 		nil,
@@ -226,7 +230,7 @@ func TestMultistate_GetMultistatesByRequiredAndForbiddenStateIds_NoError(t *test
 	mst.MustAddAction(
 		"sign_a", "Sign A", Empty(),
 		multistate.States{signedA}, nil,
-		func(_ context.Context, _ interface{}, _ ...interface{}) error {
+		func(_ context.Context, _ multistate.Entity, _ ...interface{}) error {
 			return nil
 		},
 		nil,
@@ -235,7 +239,7 @@ func TestMultistate_GetMultistatesByRequiredAndForbiddenStateIds_NoError(t *test
 	mst.MustAddAction(
 		"sign_b", "Sign B", Empty(),
 		multistate.States{signedB}, nil,
-		func(_ context.Context, _ interface{}, _ ...interface{}) error {
+		func(_ context.Context, _ multistate.Entity, _ ...interface{}) error {
 			return nil
 		},
 		nil,
@@ -244,7 +248,7 @@ func TestMultistate_GetMultistatesByRequiredAndForbiddenStateIds_NoError(t *test
 	mst.MustAddAction(
 		"sign_c", "Sign C", And(Or(signedA, signedB), Not(signedC)),
 		multistate.States{signedC}, nil,
-		func(_ context.Context, _ interface{}, _ ...interface{}) error {
+		func(_ context.Context, _ multistate.Entity, _ ...interface{}) error {
 			return nil
 		},
 		nil,
@@ -253,7 +257,7 @@ func TestMultistate_GetMultistatesByRequiredAndForbiddenStateIds_NoError(t *test
 	mst.MustAddAction(
 		"sign_d", "Sign D", And(Or(signedC, signedE), Not(signedD)),
 		multistate.States{signedD}, nil,
-		func(_ context.Context, _ interface{}, _ ...interface{}) error {
+		func(_ context.Context, _ multistate.Entity, _ ...interface{}) error {
 			return nil
 		},
 		nil,
@@ -262,7 +266,7 @@ func TestMultistate_GetMultistatesByRequiredAndForbiddenStateIds_NoError(t *test
 	mst.MustAddAction(
 		"sign_e", "Sign E", And(Or(signedC, signedD), Not(signedE)),
 		multistate.States{signedE}, multistate.States{signedC},
-		func(_ context.Context, _ interface{}, _ ...interface{}) error {
+		func(_ context.Context, _ multistate.Entity, _ ...interface{}) error {
 			return nil
 		},
 		nil,
@@ -294,7 +298,7 @@ func TestMultistate_GetMultistatesByRequiredAndForbiddenStateIds_ErrorInvalidReq
 	mst.MustAddAction(
 		"sign_a", "Sign A", Empty(),
 		multistate.States{signedA}, nil,
-		func(_ context.Context, _ interface{}, _ ...interface{}) error {
+		func(_ context.Context, _ multistate.Entity, _ ...interface{}) error {
 			return nil
 		},
 		nil,
@@ -303,7 +307,7 @@ func TestMultistate_GetMultistatesByRequiredAndForbiddenStateIds_ErrorInvalidReq
 	mst.MustAddAction(
 		"sign_b", "Sign B", Empty(),
 		multistate.States{signedB}, nil,
-		func(_ context.Context, _ interface{}, _ ...interface{}) error {
+		func(_ context.Context, _ multistate.Entity, _ ...interface{}) error {
 			return nil
 		},
 		nil,
@@ -312,7 +316,7 @@ func TestMultistate_GetMultistatesByRequiredAndForbiddenStateIds_ErrorInvalidReq
 	mst.MustAddAction(
 		"sign_c", "Sign C", And(Or(signedA, signedB), Not(signedC)),
 		multistate.States{signedC}, nil,
-		func(_ context.Context, _ interface{}, _ ...interface{}) error {
+		func(_ context.Context, _ multistate.Entity, _ ...interface{}) error {
 			return nil
 		},
 		nil,
@@ -339,7 +343,7 @@ func TestMultistate_GetMultistatesByRequiredAndForbiddenStateIds_ErrorInvalidFor
 	mst.MustAddAction(
 		"sign_a", "Sign A", Empty(),
 		multistate.States{signedA}, nil,
-		func(_ context.Context, _ interface{}, _ ...interface{}) error {
+		func(_ context.Context, _ multistate.Entity, _ ...interface{}) error {
 			return nil
 		},
 		nil,
@@ -348,7 +352,7 @@ func TestMultistate_GetMultistatesByRequiredAndForbiddenStateIds_ErrorInvalidFor
 	mst.MustAddAction(
 		"sign_b", "Sign B", Empty(),
 		multistate.States{signedB}, nil,
-		func(_ context.Context, _ interface{}, _ ...interface{}) error {
+		func(_ context.Context, _ multistate.Entity, _ ...interface{}) error {
 			return nil
 		},
 		nil,
@@ -357,7 +361,7 @@ func TestMultistate_GetMultistatesByRequiredAndForbiddenStateIds_ErrorInvalidFor
 	mst.MustAddAction(
 		"sign_c", "Sign C", And(Or(signedA, signedB), Not(signedC)),
 		multistate.States{signedC}, nil,
-		func(_ context.Context, _ interface{}, _ ...interface{}) error {
+		func(_ context.Context, _ multistate.Entity, _ ...interface{}) error {
 			return nil
 		},
 		nil,


### PR DESCRIPTION
Add the `GetTx` method to the `Entity` interface to support transaction propagation without context. 
Also, change `id interface{}` in `ActionDoFunc` to `entity Entity`, since it is redundant. `Do` function is always called with the `entity` argument."